### PR TITLE
Rodina/add post checkout hook

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+printf '\npost-checkout hook\n\n'
+
+git clean -fdX

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ venv.bak/
 
 # VS Code
 .vscode/*
+.vs/*


### PR DESCRIPTION
Т.к. хуки не могут быть закоммичены напрямую из соображений безопасности, то добавляю отдельную папку для этого.  Для того, чтобы воспользоваться этим файлом надо либо создать symlink на него из .git/hooks/, либо вручную скопипастить.